### PR TITLE
Fix "pretty formatting" of pointer implementations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ use core::ops::Deref;
 /// To make implementation of traits in this library consistent with implementation of same
 /// traits on primitive pointers, we have to manually implement them.
 macro_rules! trait_impl {
-    ($SelfType:ident, $SelfName:literal) => {
+    ($SelfType:ident) => {
         impl<T> Clone for $SelfType<T> {
             #[inline(always)]
             fn clone(&self) -> Self {
@@ -80,11 +80,7 @@ macro_rules! trait_impl {
 
         impl<T> core::fmt::Debug for $SelfType<T> {
             fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-                use core::fmt::Write;
-                f.write_str($SelfName)?;
-                f.write_char('(')?;
-                core::fmt::Debug::fmt(&self.0, f)?;
-                f.write_char(')')
+                f.debug_tuple(stringify!($SelfType)).field(&self.0).finish()
             }
         }
 
@@ -105,7 +101,7 @@ pub struct SyncMutPtr<T>(*mut T);
 unsafe impl<T> Sync for SyncMutPtr<T> {}
 unsafe impl<T> Send for SyncMutPtr<T> {}
 
-trait_impl!(SyncMutPtr, "SyncMutPtr");
+trait_impl!(SyncMutPtr);
 
 impl<T> SyncMutPtr<T> {
     ///
@@ -218,7 +214,7 @@ pub struct SyncConstPtr<T>(*const T);
 unsafe impl<T> Sync for SyncConstPtr<T> {}
 unsafe impl<T> Send for SyncConstPtr<T> {}
 
-trait_impl!(SyncConstPtr, "SyncConstPtr");
+trait_impl!(SyncConstPtr);
 
 impl<T> SyncConstPtr<T> {
     ///
@@ -329,7 +325,7 @@ pub struct SendMutPtr<T>(*mut T);
 
 unsafe impl<T> Send for SendMutPtr<T> {}
 
-trait_impl!(SendMutPtr, "SendMutPtr");
+trait_impl!(SendMutPtr);
 
 impl<T> SendMutPtr<T> {
     ///
@@ -450,7 +446,7 @@ pub struct SendConstPtr<T>(*const T);
 
 unsafe impl<T> Send for SendConstPtr<T> {}
 
-trait_impl!(SendConstPtr, "SendConstPtr");
+trait_impl!(SendConstPtr);
 
 impl<T> SendConstPtr<T> {
     ///

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -16,6 +16,16 @@ pub fn test_debug() {
     assert_eq!(format!("{:?}", n), "SendConstPtr(0x0)");
     let n = unsafe { null_mut::<c_void>().as_send_mut() };
     assert_eq!(format!("{:?}", n), "SendMutPtr(0x0)");
+
+    let n = unsafe { null_mut::<c_void>().as_sync_mut() };
+    assert_eq!(format!("{:#?}", n), "SyncMutPtr(\n    0x0000000000000000,\n)");
+    let n = unsafe { null_mut::<c_void>().as_sync_const() };
+    assert_eq!(format!("{:#?}", n), "SyncConstPtr(\n    0x0000000000000000,\n)");
+    let n = unsafe { null_mut::<c_void>().as_send_const() };
+    assert_eq!(format!("{:#?}", n), "SendConstPtr(\n    0x0000000000000000,\n)");
+    let n = unsafe { null_mut::<c_void>().as_send_mut() };
+    assert_eq!(format!("{:#?}", n), "SendMutPtr(\n    0x0000000000000000,\n)");
+
 }
 
 #[test]


### PR DESCRIPTION
Rust supports "pretty debug formatting" using `{:#?}` formatting string which is an alternative to default `{:?}`, it breaks struct to multi line and, adds indentation, etc.

https://github.com/AlexanderSchuetz97/sync-ptr/commit/263a169f11f5d41fcd00612c7c2c7833e6c279db introduced change in how pointers are formatted here, and that change was undesirable, we preferred to keep formatting without changes.

There was a fix which addressed compatibility concern but it did not touch "pretty formatting" case.

This change brings formatting back to parity with what it was pre-263a169f11f5d41fcd00612c7c2c7833e6c279db